### PR TITLE
Replace callbacks with coroutines

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,4 +71,11 @@ dependencies {
 
     // by viewModels()
     implementation "androidx.activity:activity-ktx:1.2.2"
+
+    // Task.await()
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.3.9"
+
+    // LiveData extensions
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.4.0"
+
 }

--- a/app/src/main/java/com/dsphoenix/soundvault/data/AudioRepository.kt
+++ b/app/src/main/java/com/dsphoenix/soundvault/data/AudioRepository.kt
@@ -1,21 +1,21 @@
 package com.dsphoenix.soundvault.data
 
-import androidx.lifecycle.LiveData
 import com.dsphoenix.soundvault.data.model.Track
 import com.dsphoenix.soundvault.utils.firebase.FirebaseStorageService
 import com.dsphoenix.soundvault.utils.firebase.FirestoreService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class AudioRepository @Inject constructor(
     private val firestoreService: FirestoreService,
     private val firebaseStorage: FirebaseStorageService
 ) {
-    fun uploadTrack(track: Track) {
+    suspend fun uploadTrack(track: Track) {
         val updatedTrack = firestoreService.writeTrack(track)
         firebaseStorage.uploadTrack(updatedTrack)
     }
 
-    fun getTracks(): LiveData<List<Track>> {
-        return firestoreService.getTracks()
-    }
+    fun getTracks(): Flow<List<Track>> =
+        firestoreService.getTracks()
 }

--- a/app/src/main/java/com/dsphoenix/soundvault/ui/homescreen/HomeViewModel.kt
+++ b/app/src/main/java/com/dsphoenix/soundvault/ui/homescreen/HomeViewModel.kt
@@ -2,6 +2,7 @@ package com.dsphoenix.soundvault.ui.homescreen
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import com.dsphoenix.soundvault.data.AudioRepository
 import com.dsphoenix.soundvault.data.model.Track
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,5 +12,5 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     audioRepository: AudioRepository
 ) : ViewModel() {
-    val tracks: LiveData<List<Track>> = audioRepository.getTracks()
+    val tracks: LiveData<List<Track>> = audioRepository.getTracks().asLiveData()
 }

--- a/app/src/main/java/com/dsphoenix/soundvault/ui/uploadscreen/UploadFileViewModel.kt
+++ b/app/src/main/java/com/dsphoenix/soundvault/ui/uploadscreen/UploadFileViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.*
 import com.dsphoenix.soundvault.data.AudioRepository
 import com.dsphoenix.soundvault.data.model.Track
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 private const val TAG = "UploadFileViewModel"
@@ -35,6 +36,8 @@ class UploadFileViewModel @Inject constructor(
             remotePath = "audio/${filename.value}"
         )
 
-        audioRepository.uploadTrack(track)
+        viewModelScope.launch {
+            audioRepository.uploadTrack(track)
+        }
     }
 }


### PR DESCRIPTION
Firebase services now use coroutines instead of callbacks:
  - Firestore service uses Flow instead of forwarding LiveData
  - Firebase storage service uploads data with suspend functions